### PR TITLE
Fix dangling references on deletion

### DIFF
--- a/src/gestaltdb/graphdb.py
+++ b/src/gestaltdb/graphdb.py
@@ -568,9 +568,22 @@ class GraphDB:
         Examples:
             >>> graph_db.delete_node(b"drug-1")  # doctest: +SKIP
         """
+        node_id = self.node_key_to_bytes(node_id)
+        incident_edge_ids = []
+        for edge_id in self.store.get_edge_keys_generator():
+            edge = self.get_edge(edge_id)
+            if edge is None:
+                continue
+            if self.node_key_to_bytes(edge.source) == node_id or self.node_key_to_bytes(edge.target) == node_id:
+                incident_edge_ids.append(edge_id)
+
+        for edge_id in incident_edge_ids:
+            self.delete_edge(edge_id)
+
         old_node = self.get_node(node_id)
         if old_node is not None:
             self._delete_node_indexes(old_node)
+        self.store.delete_adjacency(node_id)
         self.store.delete_node(node_id)
 
     def _put_node_indexes(self, node: Node):
@@ -969,6 +982,7 @@ class GraphDB:
         if old_edge is not None:
             self._delete_typed_adjacency_for_edge(old_edge)
             self._delete_edge_indexes(old_edge)
+            self._remove_edge_from_endpoint_adjacencies(old_edge)
         value = self.entity_serializer.serialize(edge,'Edge')
         self.store.put_edge(edge.get_id_bytes, value)
         self._put_typed_adjacency_for_edge(edge)
@@ -986,7 +1000,8 @@ class GraphDB:
                     self.store.put_adjacency(io_node_key, serialized_adj_list)
                 else:
                     adj_edge_list = self.entity_serializer.deserialize(adj_list,'AdjacencyList')
-                    adj_edge_list.setdefault(dict_flag, []).append(edge.get_id)
+                    if edge.get_id not in adj_edge_list.setdefault(dict_flag, []):
+                        adj_edge_list[dict_flag].append(edge.get_id)
                     self.store.put_adjacency(io_node_key, self.serializer.serialize(adj_edge_list))
 
     def _put_typed_adjacency_for_edge(self, edge: Edge):
@@ -2186,18 +2201,35 @@ class GraphDB:
 
         self._delete_typed_adjacency_for_edge(e)
         self._delete_edge_indexes(e)
-
-        # Remove edge_id from adjacency of source
-        _source_edge_bytes = edge_key_serializer(e.source)
-        self._remove_edge_from_adjacency(_source_edge_bytes, edge_id)
-        # Remove edge_id from adjacency of target
-        if e.target != e.source:
-            _target_edge_bytes = edge_key_serializer(e.target)
-            self._remove_edge_from_adjacency(_target_edge_bytes, edge_id)
+        self._remove_edge_from_endpoint_adjacencies(e)
 
         # If your store had a 'delete_edge' method, you'd call it here.
         # We'll assume you add that to KVStore if needed, e.g.:
         self.store.delete_edge(edge_id)
+
+    def _edge_id_variants(self, edge_id):
+        """Return string/byte forms used by legacy adjacency records."""
+        variants = [edge_id]
+        if isinstance(edge_id, bytes):
+            try:
+                edge_id_text = edge_id.decode("utf-8")
+            except UnicodeDecodeError:
+                edge_id_text = None
+            if edge_id_text is not None:
+                variants.append(edge_id_text)
+        elif isinstance(edge_id, str):
+            variants.append(edge_id.encode("utf-8"))
+        return variants
+
+    def _remove_edge_from_endpoint_adjacencies(self, edge: Edge):
+        """Remove an edge from the legacy adjacency blobs for its endpoints."""
+        source_id = self.node_key_to_bytes(edge.source)
+        target_id = self.node_key_to_bytes(edge.target)
+        self._remove_edge_from_adjacency(source_id, edge.get_id)
+        self._remove_edge_from_adjacency(source_id, edge.get_id_bytes)
+        if target_id != source_id:
+            self._remove_edge_from_adjacency(target_id, edge.get_id)
+            self._remove_edge_from_adjacency(target_id, edge.get_id_bytes)
 
     def _remove_edge_from_adjacency(self, node_id: str, edge_id: str):
         """Remove an edge ID from a node's stored adjacency lists.
@@ -2210,13 +2242,18 @@ class GraphDB:
         
         adj_list = self.get_adjacency_list(node_id,return_raw = True)
         _changed = False
+        edge_id_variants = set(self._edge_id_variants(edge_id))
         for _dir in ['source', 'target']:
             if _dir in adj_list:
-                if edge_id in adj_list[_dir]:
-                    adj_list[_dir].remove(edge_id)
+                filtered_edges = [existing_edge_id for existing_edge_id in adj_list[_dir] if existing_edge_id not in edge_id_variants]
+                if len(filtered_edges) != len(adj_list[_dir]):
+                    adj_list[_dir] = filtered_edges
                     _changed = True
         if _changed:
-            self.put_adjacency_list(node_id, adj_list)
+            if not adj_list.get('source') and not adj_list.get('target'):
+                self.store.delete_adjacency(node_id)
+            else:
+                self.put_adjacency_list(node_id, adj_list)
 
     # -----------------------
     # BFS Example
@@ -2280,6 +2317,7 @@ class GraphDB:
                 if old_edge is not None:
                     self._delete_typed_adjacency_for_edge(old_edge)
                     self._delete_edge_indexes(old_edge)
+                    self._remove_edge_from_endpoint_adjacencies(old_edge)
             e_bytes = self.entity_serializer.serialize(e, 'Edge')
             _source = self.node_key_to_bytes(e.source)
             _target = self.node_key_to_bytes(e.target)

--- a/src/gestaltdb/kvstores.py
+++ b/src/gestaltdb/kvstores.py
@@ -231,6 +231,10 @@ class KVStore:
         """Retrieve multiple serialized edges by key."""
         raise NotImplementedError
 
+    def delete_adjacency(self, node_id: bytes):
+        """Delete a serialized adjacency list for a node."""
+        raise NotImplementedError
+
     def put_typed_adjacency(self, source_id: bytes, target_id: bytes, edge_type: str, edge_id: bytes):
         """Store typed adjacency records for an edge."""
         raise NotImplementedError
@@ -608,6 +612,11 @@ class LMDBStore(KVStore):
                     results[node_id] = data
         return results
 
+    def delete_adjacency(self, node_id: bytes):
+        """Delete a serialized adjacency list for a node."""
+        with self.env.begin(write=True, db=self.adj_db) as txn:
+            txn.delete(node_id)
+
     # ----- Typed Adjacency Methods -----
     def put_typed_adjacency(self, source_id: bytes, target_id: bytes, edge_type: str, edge_id: bytes):
         """Store forward and reverse typed adjacency records."""
@@ -907,6 +916,10 @@ class LevelDBStore(KVStore):
             if data is not None:
                 results[node_id] = data
         return results
+
+    def delete_adjacency(self, node_id: bytes):
+        """Delete a serialized adjacency list for a node."""
+        self.db_adj.delete(node_id)
 
     # ----- Typed Adjacency Methods -----
     def put_typed_adjacency(self, source_id: bytes, target_id: bytes, edge_type: str, edge_id: bytes):
@@ -1220,6 +1233,10 @@ class PyRexStore(KVStore):
             if data is not None:
                 results[node_id] = data
         return results
+
+    def delete_adjacency(self, node_id: bytes):
+        """Delete a serialized adjacency list for a node."""
+        self.db.delete(self._key(b"A", node_id), self.write_options)
 
     def put_typed_adjacency(self, source_id: bytes, target_id: bytes, edge_type: str, edge_id: bytes):
         """Store forward and reverse typed adjacency records."""

--- a/tests/test_graphdb_interfaces.py
+++ b/tests/test_graphdb_interfaces.py
@@ -80,6 +80,49 @@ def test_single_edge(graph_db):
     assert graph_db.get_edge(edge_ab.get_id_bytes) is None
 
 
+def test_deleting_edge_removes_legacy_adjacency(graph_db):
+    graph_db.put_node(Node(node_id="n1"))
+    graph_db.put_node(Node(node_id="n2"))
+    graph_db.put_edge(Edge(edge_id="e1", source="n1", target="n2", properties={"type": "rel"}))
+
+    graph_db.delete_edge(b"e1")
+
+    assert graph_db.get_adjacency_list(b"n1", direction="any") == []
+    assert graph_db.get_adjacency_list(b"n2", direction="any") == []
+
+
+def test_replacing_edge_removes_legacy_adjacency_from_old_endpoints(graph_db):
+    for node_id in ["n1", "n2", "n3", "n4"]:
+        graph_db.put_node(Node(node_id=node_id))
+
+    graph_db.put_edge(Edge(edge_id="e1", source="n1", target="n2", properties={"type": "old"}))
+    graph_db.put_edge(Edge(edge_id="e1", source="n3", target="n4", properties={"type": "new"}))
+
+    assert graph_db.get_adjacency_list(b"n1", direction="any") == []
+    assert graph_db.get_adjacency_list(b"n2", direction="any") == []
+    assert graph_db.get_adjacency_list(b"n3", direction="any") == ["e1"]
+    assert graph_db.get_adjacency_list(b"n4", direction="any") == ["e1"]
+
+
+def test_deleting_node_removes_incident_edges_and_edge_indexes(graph_db):
+    graph_db.put_node(Node(node_id="n1"))
+    graph_db.put_node(Node(node_id="n2"))
+    graph_db.put_node(Node(node_id="n3"))
+    graph_db.put_edge(Edge(edge_id="e1", source="n1", target="n2", properties={"type": "rel", "score": 1}))
+    graph_db.put_edge(Edge(edge_id="e2", source="n2", target="n3", properties={"type": "rel", "score": 2}))
+    graph_db.create_edge_property_index("score")
+
+    graph_db.delete_node(b"n2")
+
+    assert graph_db.get_node(b"n2") is None
+    assert graph_db.get_edge(b"e1") is None
+    assert graph_db.get_edge(b"e2") is None
+    assert graph_db.neighbors_by_edge_type("n1", "rel", direction="out") == []
+    assert graph_db.neighbors_by_edge_type("n3", "rel", direction="in") == []
+    assert graph_db.edges_by_type("rel") == []
+    assert graph_db.edges_by_property("score", 1) == []
+
+
 def test_bfs_simple(graph_db):
     node_a = Node(properties={"label": "A"})
     node_b = Node(properties={"label": "B"})

--- a/tests/test_kvstores.py
+++ b/tests/test_kvstores.py
@@ -33,6 +33,7 @@ def test_kvstore_abstract_methods_raise_not_implemented():
         lambda: store.get_nodes_bulk([b"n"]),
         lambda: store.put_edges_bulk({b"e": b"v"}),
         lambda: store.get_edges_bulk([b"e"]),
+        lambda: store.delete_adjacency(b"n"),
         lambda: store.put_typed_adjacency(b"n1", b"n2", "rel", b"e"),
         lambda: store.delete_typed_adjacency(b"n1", b"n2", "rel", b"e"),
         lambda: list(store.iter_typed_adjacency(b"n1", "rel")),


### PR DESCRIPTION
## Summary
- Delete incident edges before removing a node so edge records, typed adjacency, and edge secondary indexes do not dangle.
- Clean legacy adjacency blobs when deleting or replacing edges, including both string and bytes edge ID representations.
- Add delete_adjacency support to LMDB, LevelDB, and PyRex backends so empty adjacency blobs are removed rather than retained.
- Add regression tests covering edge deletion, edge replacement, node deletion, and the KV interface contract.

## Verification
- uv run pytest
- Result: 256 passed, 84 skipped