### PR TITLE
Fix traversal direction semantics

### DIFF
--- a/src/gestaltdb/graphdb.py
+++ b/src/gestaltdb/graphdb.py
@@ -1400,8 +1400,12 @@ class GraphDB:
 
         node_id_bytes = self.node_key_to_bytes(node_id)
         directions = ['out', 'in'] if direction == 'any' else [direction]
+        seen_edge_ids = set()
         for current_direction in directions:
             for edge_id, neighbor_id in self.store.iter_typed_adjacency(node_id_bytes, edge_type, current_direction):
+                if direction == 'any' and edge_id in seen_edge_ids:
+                    continue
+                seen_edge_ids.add(edge_id)
                 if current_direction == 'out':
                     source_id = node_id_bytes
                     target_id = neighbor_id
@@ -2172,14 +2176,17 @@ class GraphDB:
         if return_raw:
             return adj
 
-        if direction == 'forward':
-            return adj.get('target',[]) 
-        if direction == 'backward':
+        if direction in {'forward', 'out'}:
             return adj.get('source',[])
-        if direction == 'any' : 
-            _s = adj.get('source',[])
-            _t = adj.get('target',[])
-            return list(set(_s).union(set(_t)))
+        if direction in {'backward', 'in'}:
+            return adj.get('target',[])
+        if direction == 'any' :
+            edge_ids = []
+            for edge_id in adj.get('source',[]) + adj.get('target',[]):
+                if edge_id not in edge_ids:
+                    edge_ids.append(edge_id)
+            return edge_ids
+        raise ValueError("direction must be 'forward', 'backward', 'out', 'in', or 'any'")
         
     def put_adjacency_list(self, node_id: str, edges_list: list[str]):
         """Stores the adjacency list for node_id."""
@@ -2258,11 +2265,14 @@ class GraphDB:
     # -----------------------
     # BFS Example
     # -----------------------
-    def bfs(self, start_node_id: bytes, direction = 'any', edge_key_serializer = lambda x : x.encode('utf-8'), node_key_serializer = lambda x : x.encode('utf-8')) -> list[str]:
+    def bfs(self, start_node_id: bytes, direction = 'any', edge_key_serializer = None, node_key_serializer = None) -> list[str]:
         """
         Returns a list of node_ids in BFS order starting from `start_node_id`.
         Demonstrates how adjacency is used for graph traversal.
         """
+        edge_key_serializer = edge_key_serializer or self.edge_key_to_bytes
+        node_key_serializer = node_key_serializer or self.node_key_to_bytes
+        start_node_id = self.node_key_to_bytes(start_node_id)
         visited = set()
         queue = [start_node_id]
         result = []

--- a/tests/test_graphdb_interfaces.py
+++ b/tests/test_graphdb_interfaces.py
@@ -143,6 +143,37 @@ def test_bfs_simple(graph_db):
     assert len(bfs_result) == 3
 
 
+def test_legacy_adjacency_direction_semantics(graph_db):
+    graph_db.put_node(Node(node_id="source"))
+    graph_db.put_node(Node(node_id="target"))
+    graph_db.put_edge(Edge(edge_id="e1", source="source", target="target"))
+
+    assert graph_db.get_adjacency_list(b"source", direction="forward") == ["e1"]
+    assert graph_db.get_adjacency_list(b"source", direction="out") == ["e1"]
+    assert graph_db.get_adjacency_list(b"source", direction="backward") == []
+    assert graph_db.get_adjacency_list(b"target", direction="backward") == ["e1"]
+    assert graph_db.get_adjacency_list(b"target", direction="in") == ["e1"]
+    assert graph_db.get_adjacency_list(b"target", direction="forward") == []
+
+
+def test_bfs_direction_semantics(graph_db):
+    graph_db.put_node(Node(node_id="source"))
+    graph_db.put_node(Node(node_id="target"))
+    graph_db.put_edge(Edge(edge_id="e1", source="source", target="target"))
+
+    assert graph_db.bfs(b"source", direction="forward") == [b"source", b"target"]
+    assert graph_db.bfs(b"target", direction="forward") == [b"target"]
+    assert graph_db.bfs(b"target", direction="backward") == [b"target", b"source"]
+
+
+def test_bfs_handles_bulk_adjacency_byte_edge_ids(graph_db):
+    graph_db.put_node(Node(node_id="n1"))
+    graph_db.put_node(Node(node_id="n2"))
+    graph_db.put_edges_bulk([Edge(edge_id="e1", source="n1", target="n2")])
+
+    assert graph_db.bfs(b"n1") == [b"n1", b"n2"]
+
+
 def test_bulk_nodes(graph_db):
     nodes = [Node(properties={"name": f"User{i}"}) for i in range(5)]
 

--- a/tests/test_typed_traversal.py
+++ b/tests/test_typed_traversal.py
@@ -12,6 +12,17 @@ def test_typed_adjacency_filters_type_and_direction(graph_db):
     assert graph_db.neighbors_by_edge_type("drug-1", "drug-to-disease", direction="out") == [b"disease-1"]
 
 
+def test_typed_adjacency_any_deduplicates_self_loops(graph_db):
+    graph_db.put_node(Node(node_id="n1"))
+    graph_db.put_edge(Edge(edge_id="self", source="n1", target="n1", properties={"type": "self"}))
+
+    records = graph_db.get_typed_adjacency("n1", "self", direction="any")
+
+    assert len(records) == 1
+    assert records[0]["edge_id"] == b"self"
+    assert records[0]["neighbor_id"] == b"n1"
+
+
 def test_deleting_typed_edge_removes_typed_adjacency(graph_db):
     populate_typed_graph(graph_db)
 


### PR DESCRIPTION
## Summary
- Correct legacy adjacency direction mapping so forward/out returns outgoing edges from the source endpoint and backward/in returns incoming edges to the target endpoint.
- Normalize BFS key handling through the graph key normalizers so traversal works for both string edge IDs from put_edge and byte edge IDs from put_edges_bulk.
- Preserve stable order for undirected legacy adjacency and validate invalid direction values.
- De-duplicate typed direction=any traversal for self-loop edges so the same edge is not yielded twice.

## Regression Coverage
- Legacy adjacency direction semantics.
- Directed BFS semantics.
- BFS after bulk edge insertion with byte edge IDs.
- Typed any traversal over self-loops.

## Verification
- uv run pytest
- Result: 264 passed, 88 skipped