### PR TITLE
Add transactional backend support

### DIFF
--- a/benchmarks.py
+++ b/benchmarks.py
@@ -5,6 +5,7 @@ Run examples:
     python benchmarks.py --backend lmdb --nodes 10000 --edges 50000
     python benchmarks.py --backend leveldb --nodes 10000 --edges 50000
     python benchmarks.py --backend rocksdb --nodes 10000 --edges 50000 --rocksdb-bloom-bits 10
+    python benchmarks.py --backend rocksdb --nodes 10000 --edges 50000 --rocksdb-transactional
 
 The benchmark intentionally uses the public API. It is designed to catch large
 performance regressions and compare ingestion modes, not to be a full profiler.
@@ -48,6 +49,7 @@ def open_graph(args, path):
                 write_buffer_size=args.rocksdb_write_buffer_size,
                 bloom_bits_per_key=args.rocksdb_bloom_bits,
                 disable_wal=args.rocksdb_disable_wal,
+                transactional=args.rocksdb_transactional,
             ),
             PickleSerializer(),
         )
@@ -145,6 +147,7 @@ def main():
     parser.add_argument("--rocksdb-write-buffer-size", type=int, default=None)
     parser.add_argument("--rocksdb-bloom-bits", type=float, default=None)
     parser.add_argument("--rocksdb-disable-wal", action="store_true")
+    parser.add_argument("--rocksdb-transactional", action="store_true")
     run_benchmark(parser.parse_args())
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ sys.path.insert(0, str(ROOT / "src"))
 project = "GestaltDB"
 author = "Mylonas Charilaos"
 copyright = "2026, Mylonas Charilaos"
-release = "0.4.0"
+release = "0.5.0"
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -84,7 +84,7 @@ Optional Dependencies
    LevelDB key-value backend through ``plyvel``.
 
 ``rocksdb``
-   RocksDB key-value backend through ``pyrex-rocksdb>=0.3.0a0``.
+   RocksDB key-value backend through ``pyrex-rocksdb>=0.4.1``.
 
 ``arrow``
    Arrow array support through ``pyarrow`` for columnar ingestion helpers.
@@ -94,7 +94,7 @@ Optional Dependencies
 
 ``fast-ingest``
    Convenience extra for ``pyarrow``, ``polars``, and
-   ``pyrex-rocksdb>=0.3.0a0``.
+   ``pyrex-rocksdb>=0.4.1``.
 
 ``msgpack``
    MessagePack serializer.

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -13,6 +13,10 @@ shape of the workload rather than by a single global default:
 
 - Use ``PyRexStore``/RocksDB for large append-only loads, columnar ingestion, and
   write-heavy workloads where native batch writes and RocksDB tuning matter.
+- Use ``PyRexStore(transactional=True)`` only when graph-level RocksDB
+  transactions are required. The transaction-capable backend currently cannot use
+  PyRex's native columnar writer, so append-only bulk loads should usually keep
+  the default RocksDB backend.
 - Use ``LevelDBStore`` for simple local graphs, predictable installs through
   ``plyvel``, and workloads where the graph is small enough that Python object
   construction dominates storage I/O.
@@ -60,6 +64,7 @@ workload.
 
    python benchmarks.py --backend leveldb --nodes 20000 --edges 100000 --batch-size 10000 --append-only
    python benchmarks.py --backend rocksdb --nodes 20000 --edges 100000 --batch-size 10000 --append-only
+   python benchmarks.py --backend rocksdb --nodes 20000 --edges 100000 --batch-size 10000 --append-only --rocksdb-transactional
 
 Use ``scripts/benchmark_matrix.py`` for larger matrix runs across graph sizes,
 backends, core counts, and ingestion modes.
@@ -68,6 +73,7 @@ backends, core counts, and ingestion modes.
 
    uv run python scripts/benchmark_matrix.py \
       --sizes 10000 100000 1000000 \
+      --edge-multiplier 1 \
       --cores 1 2 4 \
       --backends leveldb rocksdb \
       --ingestion-modes object arrow polars \
@@ -79,11 +85,29 @@ backends, core counts, and ingestion modes.
 The matrix writes CSV and JSONL outputs and reopens the database before traversal
 workloads so traversal does not only measure Python-side object state.
 
+To compare default RocksDB with transaction-capable RocksDB on the same 5
+edges/node shape used by the local result tables below:
+
+.. code-block:: sh
+
+   python scripts/benchmark_matrix.py \
+      --backends rocksdb \
+      --rocksdb-configs parallel-buffer64mb-bloom10 parallel-buffer64mb-bloom10-transactional \
+      --sizes 10000 100000 \
+      --edge-multiplier 5 \
+      --cores 4 \
+      --ingestion-modes arrow polars \
+      --serializer pickle \
+      --chunk-size 10000 \
+      --samples 100 \
+      --sample-size 5 \
+      --output-dir benchmark_results/transactions_rocksdb_YYYYMMDD
+
 Columnar Ingestion Benchmarks
 -----------------------------
 
 Columnar ingestion accepts already-serialized node and edge payloads. With
-``PyRexStore`` and ``pyrex-rocksdb>=0.3.0a0``, RocksDB can use PyRex's native
+``PyRexStore`` and ``pyrex-rocksdb>=0.4.1``, RocksDB can use PyRex's native
 ``write_columnar_batch`` path. When Arrow-backed string or binary arrays are
 passed, GestaltDB preserves those arrays through chunking and passes value
 columns directly to PyRex instead of materializing Python ``bytes`` for every
@@ -218,6 +242,97 @@ Interpretation:
   speedups. The fastest mode for append-only writes is not always the fastest mode
   for ingest-plus-query-ready indexes.
 
+Transaction-Capable RocksDB Benchmark
+-------------------------------------
+
+``PyRexStore(transactional=True)`` opens RocksDB through PyRex's
+``TransactionDB`` support. It provides graph-level transactions through
+``GraphDB.transaction()``, and regular direct writes still work through the same
+public GestaltDB APIs. The trade-off is that PyRex 0.4.1 exposes native
+``write_columnar_batch`` on ``PyRocksDB`` but not on ``TransactionDB``. The
+transaction-capable backend therefore falls back to Python ``PyWriteBatch`` paths
+for columnar ingestion.
+
+A focused local run on 2026-08-16 used ``pyrex-rocksdb==0.4.1``, 4 cores,
+RocksDB parallelism 4, ``max_background_jobs=4``, a 64 MiB write buffer, Bloom
+filters, Pickle payloads, chunk size 10,000, and 5 edges per node. Dataset
+generation and traversal validation were included in the benchmark script's usual
+way; the table below reports only write-phase times.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Nodes / edges
+     - Mode
+     - RocksDB backend
+     - Native columnar
+     - Node write
+     - Edge write
+   * - 10,000 / 50,000
+     - Arrow
+     - default
+     - yes
+     - 0.041 s
+     - 0.185 s
+   * - 10,000 / 50,000
+     - Arrow
+     - transaction-capable
+     - no
+     - 0.049 s
+     - 0.345 s
+   * - 10,000 / 50,000
+     - Polars
+     - default
+     - yes
+     - 0.046 s
+     - 0.187 s
+   * - 10,000 / 50,000
+     - Polars
+     - transaction-capable
+     - no
+     - 0.050 s
+     - 0.343 s
+   * - 100,000 / 500,000
+     - Arrow
+     - default
+     - yes
+     - 0.457 s
+     - 1.886 s
+   * - 100,000 / 500,000
+     - Arrow
+     - transaction-capable
+     - no
+     - 0.540 s
+     - 3.623 s
+   * - 100,000 / 500,000
+     - Polars
+     - default
+     - yes
+     - 0.429 s
+     - 1.828 s
+   * - 100,000 / 500,000
+     - Polars
+     - transaction-capable
+     - no
+     - 0.545 s
+     - 3.670 s
+
+The same environment's quick object-path benchmark with 20,000 nodes and 100,000
+append-only edges measured 77,571 edges/s on default RocksDB versus 64,649
+edges/s on transaction-capable RocksDB. Treat these results as the expected cost
+of opening the backend in transaction-capable mode, not the cost of wrapping a
+large write in one user transaction.
+
+Operational guidance:
+
+- Use default ``PyRexStore`` for reloadable bulk loads and columnar append-only
+  ingestion.
+- Use ``PyRexStore(transactional=True)`` when mutations must be atomic across
+  nodes, edges, adjacency, secondary indexes, and metadata.
+- If transaction-capable bulk ingestion needs native columnar throughput, PyRex
+  should expose ``TransactionDB.write_columnar_batch`` so GestaltDB can keep the
+  same fast path in transactional mode.
+
 RocksDB Tuning and Compaction Benchmarks
 ----------------------------------------
 
@@ -280,7 +395,7 @@ Include embedded ArcadeDB with ``uv --with``:
 .. code-block:: sh
 
    uv run --with arcadedb-embedded python scripts/benchmark_arcadedb_vs_gestaltdb.py \
-      --engines gestaltdb arcadedb \
+      --engines gestaltdb gestaltdb-tx arcadedb \
       --workloads columnar_ingest star_traversal bfs_depth typed_path rocksdb_compaction \
       --nodes 100000 \
       --edges 500000 \
@@ -293,22 +408,50 @@ The script writes raw rows and summary files grouped by engine and workload. If
 ``arcadedb-embedded`` is not installed, ArcadeDB rows are marked skipped and
 GestaltDB rows still run.
 
-Representative small local results from 2026-06-25:
+Local results from 2026-08-16 used 100,000 nodes, 500,000 edges, batch size
+100,000, 100 query iterations, one repetition, ``pyrex-rocksdb==0.4.1``, and
+``arcadedb-embedded==26.8.1``. ``gestaltdb-tx`` means
+``PyRexStore(transactional=True)``.
 
-=================== ================= ================= ================
-Workload            GestaltDB/RocksDB ArcadeDB embedded Relative result
-=================== ================= ================= ================
-columnar_ingest     0.0358 s          0.0506 s          GestaltDB 1.41x faster
-star_traversal      0.0383 s          0.0333 s          ArcadeDB 1.15x faster
-bfs_depth           0.0303 s          0.0366 s          GestaltDB 1.21x faster
-typed_path          0.0293 s          0.0404 s          GestaltDB 1.38x faster
-rocksdb_compaction  0.0022 s          Not applicable    GestaltDB only
-=================== ================= ================= ================
+.. list-table:: Older ArcadeDB-suite results
+   :header-rows: 1
 
-Interpret these results by workload. RocksDB/GestaltDB tends to show strength on
-append-only columnar ingestion and compaction-sensitive raw writes. ArcadeDB can
-be strongest when queries start from an indexed vertex and stay on native
-adjacency chains.
+   * - Workload
+     - GestaltDB/RocksDB total
+     - GestaltDB/RocksDB tx total
+     - ArcadeDB total
+     - Fastest
+   * - columnar_ingest
+     - 3.131 s
+     - 6.257 s
+     - 5.407 s
+     - GestaltDB/RocksDB
+   * - star_traversal
+     - 51.907 s
+     - 57.456 s
+     - 4.403 s
+     - ArcadeDB
+   * - bfs_depth
+     - 6.844 s
+     - 9.604 s
+     - 5.138 s
+     - ArcadeDB
+   * - typed_path
+     - 6.574 s
+     - 9.380 s
+     - 4.625 s
+     - ArcadeDB
+   * - rocksdb_compaction
+     - 0.438 s
+     - 0.545 s
+     - not applicable
+     - GestaltDB/RocksDB
+
+Interpret these results by workload. RocksDB/GestaltDB remains strongest on
+append-only columnar ingestion and compaction-sensitive raw writes. ArcadeDB is
+stronger in this older suite's traversal shapes, especially ``star_traversal``:
+that workload repeatedly materializes all 500,000 outgoing edges from one hub
+node, which is not representative of sparse point traversals.
 
 External Graph Database Benchmarks
 ----------------------------------
@@ -353,7 +496,7 @@ Run a small smoke benchmark with container-managed Neo4j and Memgraph:
 .. code-block:: sh
 
    uv run python scripts/benchmark_external_graphdbs.py \
-      --engines gestaltdb neo4j memgraph arcadedb \
+      --engines gestaltdb gestaltdb-tx neo4j memgraph arcadedb \
       --nodes 1000 \
       --edges 5000 \
       --batch-size 1000 \
@@ -366,59 +509,128 @@ Run a larger end-to-end comparison:
 .. code-block:: sh
 
    uv run python scripts/benchmark_external_graphdbs.py \
-      --engines gestaltdb neo4j memgraph arcadedb \
+      --engines gestaltdb gestaltdb-tx neo4j memgraph arcadedb \
       --workloads ingest neighbors sample_neighbors bfs_depth typed_path \
       --nodes 100000 \
       --edges 500000 \
       --batch-size 10000 \
       --iterations 100 \
-      --repetitions 3 \
+      --repetitions 1 \
       --output-dir benchmark_results/external_graphdbs_YYYYMMDD
 
 Corrected Aligned Large Results
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A local corrected aligned run on 2026-08-15 used 100,000 nodes, 500,000 edges,
-batch size 10,000, 100 traversal seeds, sample size 5, depth 3, and three
-repetitions. Neo4j used ``neo4j:5-community`` through the official Python Bolt
+A local corrected aligned run on 2026-08-16 used 100,000 nodes, 500,000 edges,
+batch size 10,000, 100 traversal seeds, sample size 5, depth 3, and one
+repetition. Neo4j used ``neo4j:5-community`` through the official Python Bolt
 driver. Memgraph used ``memgraph/memgraph:latest`` through the same Bolt driver.
-ArcadeDB used ``arcadedb-embedded``. GestaltDB used RocksDB/PyRex, JSON payloads,
-Arrow/Polars entity ingestion, deferred secondary-index maintenance, and a
-close/reopen before validation and querying. All corrected rows validated exactly
-100,000 nodes and 500,000 edges.
+ArcadeDB used ``arcadedb-embedded==26.8.1``. GestaltDB used ``pyrex-rocksdb==0.4.1``
+with JSON payloads, Arrow/Polars entity ingestion, deferred secondary-index
+maintenance, and a close/reopen before validation and querying. All rows
+validated exactly 100,000 nodes and 500,000 edges.
 
-Mean ingestion phase:
+Ingestion phase:
 
-================== =============== ===================== ====================
-Engine             Ingest seconds  Edge ingest rate      Relative to GestaltDB
-================== =============== ===================== ====================
-GestaltDB/RocksDB  2.33 s          214,227 edges/s       1.00x
-ArcadeDB embedded  5.66 s          88,561 edges/s        2.42x slower
-Memgraph           8.61 s          58,098 edges/s        3.69x slower
-Neo4j              13.45 s         37,410 edges/s        5.76x slower
-================== =============== ===================== ====================
+.. list-table::
+   :header-rows: 1
 
-Mean query phase on the already-loaded graph:
+   * - Engine
+     - Ingest seconds
+     - Edge ingest rate
+     - Relative to default GestaltDB
+   * - GestaltDB/RocksDB
+     - 1.70 s
+     - 294,727 edges/s
+     - 1.00x
+   * - GestaltDB/RocksDB transactional
+     - 2.85 s
+     - 175,728 edges/s
+     - 1.68x slower
+   * - ArcadeDB embedded
+     - 6.57 s
+     - 76,055 edges/s
+     - 3.88x slower
+   * - Memgraph
+     - 8.62 s
+     - 58,020 edges/s
+     - 5.08x slower
+   * - Neo4j
+     - 13.00 s
+     - 38,468 edges/s
+     - 7.66x slower
 
-================ ================ =============== =============== =============== ==================
-Workload         Result count     GestaltDB       ArcadeDB        Memgraph        Neo4j
-================ ================ =============== =============== =============== ==================
-neighbors        167              0.00128 s       0.0176 s        0.0188 s        0.160 s
-sample_neighbors 167              0.00128 s       0.0298 s        0.0210 s        0.166 s
-bfs_depth        3                0.000139 s      0.00383 s       0.00569 s       0.107 s
-typed_path       271              0.00283 s       0.0251 s        0.0256 s        0.190 s
-================ ================ =============== =============== =============== ==================
+Query phase on the already-loaded graph:
 
-Relative query phase compared with GestaltDB/RocksDB:
+.. list-table::
+   :header-rows: 1
 
-================ =============== =============== ==================
-Workload         ArcadeDB        Memgraph        Neo4j
-================ =============== =============== ==================
-neighbors        13.8x slower    14.7x slower    125x slower
-sample_neighbors 23.3x slower    16.4x slower    130x slower
-bfs_depth        27.5x slower    40.9x slower    767x slower
-typed_path       8.87x slower    9.06x slower    67.0x slower
-================ =============== =============== ==================
+   * - Workload
+     - Result count
+     - GestaltDB
+     - GestaltDB tx
+     - ArcadeDB
+     - Memgraph
+     - Neo4j
+   * - neighbors
+     - 167
+     - 0.00132 s
+     - 0.00154 s
+     - 0.0420 s
+     - 0.0181 s
+     - 0.174 s
+   * - sample_neighbors
+     - 167
+     - 0.00140 s
+     - 0.00168 s
+     - 0.0555 s
+     - 0.0210 s
+     - 0.188 s
+   * - bfs_depth
+     - 3
+     - 0.000144 s
+     - 0.000179 s
+     - 0.00671 s
+     - 0.00479 s
+     - 0.121 s
+   * - typed_path
+     - 271
+     - 0.00307 s
+     - 0.00369 s
+     - 0.0630 s
+     - 0.0293 s
+     - 0.230 s
+
+Relative query phase compared with default GestaltDB/RocksDB:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Workload
+     - GestaltDB tx
+     - ArcadeDB
+     - Memgraph
+     - Neo4j
+   * - neighbors
+     - 1.16x slower
+     - 31.7x slower
+     - 13.6x slower
+     - 131x slower
+   * - sample_neighbors
+     - 1.20x slower
+     - 39.8x slower
+     - 15.1x slower
+     - 135x slower
+   * - bfs_depth
+     - 1.24x slower
+     - 46.5x slower
+     - 33.2x slower
+     - 842x slower
+   * - typed_path
+     - 1.20x slower
+     - 20.5x slower
+     - 9.55x slower
+     - 75.1x slower
 
 Interpretation:
 
@@ -426,9 +638,13 @@ Interpretation:
   directly to an embedded RocksDB key-value layout using columnar batches. The
   benchmark does not pay a client/server protocol cost for ingestion, and the
   typed adjacency records used by traversal are written as sorted key prefixes.
+- The transaction-capable GestaltDB/RocksDB backend validated the same graph but
+  loaded 1.68x slower than the default RocksDB backend. This is consistent with
+  PyRex 0.4.1 exposing native columnar writes on ``PyRocksDB`` but not on
+  ``TransactionDB``.
 - ArcadeDB embedded also avoids Bolt/network overhead, but its graph batch loader
   maintains a native graph record layout and then builds a vertex ID index. On
-  this graph shape it loaded about 2.4x slower than GestaltDB but faster than the
+  this graph shape it loaded about 3.9x slower than default GestaltDB but faster than the
   Bolt-backed servers.
 - Memgraph and Neo4j ingest through batched Cypher over Bolt. That path is a fair
   Python API path, but it includes client/server round trips, Cypher planning and
@@ -447,9 +663,10 @@ Interpretation:
   This aligns semantics, but different drivers expose rows with different
   overheads.
 - The table reports ``ingest_seconds`` and ``query_seconds``. GestaltDB's
-  ``reopen_seconds`` averaged roughly 0.48 s and count validation averaged roughly
-  0.32 s; those are recorded separately in the summary file and are not included
-  in ``total_seconds``.
+  ``reopen_seconds`` was roughly 0.51 s for default RocksDB and 0.57-0.61 s for
+  transaction-capable RocksDB. Count validation was roughly 0.41-0.42 s and
+  0.44-0.45 s respectively. Those values are recorded separately in the summary
+  file and are not included in ``total_seconds``.
 
 Useful container options:
 

--- a/docs/storage-backends.rst
+++ b/docs/storage-backends.rst
@@ -9,13 +9,21 @@ Backend Selection Summary
 
 The current backend trade-offs are:
 
-==================== ============================ ============================================
-Backend              Best fit                     Main trade-offs
-==================== ============================ ============================================
-``LMDBStore``        Mature embedded storage      Requires choosing a sufficient ``map_size``
-``LevelDBStore``     Simple local graphs          No native Arrow/Polars columnar fast path
-``PyRexStore``       Large writes and ingestion   Optional dependency and RocksDB tuning knobs
-==================== ============================ ============================================
+.. list-table::
+   :header-rows: 1
+
+   * - Backend
+     - Best fit
+     - Main trade-offs
+   * - ``LMDBStore``
+     - Mature embedded storage
+     - Requires choosing a sufficient ``map_size``
+   * - ``LevelDBStore``
+     - Simple local graphs
+     - No native Arrow/Polars columnar fast path
+   * - ``PyRexStore``
+     - Large writes and ingestion
+     - Optional dependency, RocksDB tuning knobs, opt-in transactions
 
 Recommendations for the library as-is:
 
@@ -103,7 +111,7 @@ several RocksDB tuning knobs.
 ``disable_wal=True`` can be useful for bulk-loading experiments, but it weakens
 durability and should not be used as a safe default.
 
-When installed with ``pyrex-rocksdb>=0.3.0a0``, ``PyRexStore`` can use PyRex's
+When installed with ``pyrex-rocksdb>=0.4.1``, ``PyRexStore`` can use PyRex's
 native ``write_columnar_batch`` API through ``GraphDB.ingest_nodes_arrow`` and
 ``GraphDB.ingest_edges_arrow``. Serialized ``node_value`` and ``edge_value``
 columns backed by Arrow binary arrays are passed directly to PyRex's native
@@ -210,6 +218,57 @@ Backend Index Interface
 Backend implementations expose lower-level sorted index methods such as
 ``put_index_entry``, ``delete_index_entry``, ``iter_index_prefix``, and range
 index equivalents. Most users should prefer the ``GraphDB`` helpers above.
+
+Transactions
+------------
+
+GestaltDB exposes optional graph-level transactions for backends that can commit
+all graph records and indexes atomically:
+
+.. code-block:: python
+
+   with graph_db.transaction() as tx:
+       tx.put_node(Node(node_id="n1"))
+       tx.put_edge(Edge(edge_id="e1", source="n1", target="n2", properties={"type": "rel"}))
+
+The context commits on clean exit and rolls back if an exception leaves the
+block. ``LMDBStore`` supports transactions directly because LMDB transactions
+span all named sub-databases in the environment.
+
+``PyRexStore`` supports transactions when opened in transaction-capable mode with
+``pyrex-rocksdb>=0.4.1``:
+
+.. code-block:: python
+
+   store = PyRexStore(path="graph_rocksdb", transactional=True)
+   graph_db = GraphDB(store, PickleSerializer())
+
+The default ``PyRexStore`` mode remains the fastest non-transactional path and
+keeps native columnar ingestion available. Transactional PyRex writes still use
+RocksDB ``PyWriteBatch`` internally for bulk methods, but the current PyRex
+``TransactionDB`` API does not expose the native columnar writer.
+
+A focused local benchmark on this branch used 100,000 nodes, 500,000 edges,
+Pickle payloads, chunk size 10,000, four RocksDB background threads, a 64 MiB
+write buffer, and Bloom filters. The transaction-capable RocksDB backend was
+opened with ``PyRexStore(transactional=True)`` and used the same public ingestion
+API, not one giant user transaction.
+
+=========================================== ========== ========== =================
+RocksDB backend                             Node write Edge write Native columnar
+=========================================== ========== ========== =================
+default, Arrow payloads                     0.457 s    1.886 s    yes
+transaction-capable, Arrow payloads         0.540 s    3.623 s    no
+default, Polars payloads                    0.429 s    1.828 s    yes
+transaction-capable, Polars payloads        0.545 s    3.670 s    no
+=========================================== ========== ========== =================
+
+Use transaction-capable RocksDB when graph-level atomicity is required. Keep the
+default RocksDB backend for append-only bulk loads where native columnar
+ingestion is the priority.
+
+The current ``LevelDBStore`` layout uses multiple physical LevelDB databases, so
+graph-level transactions are intentionally unsupported there.
 
 Backend Selection Pattern
 -------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gestaltdb"
-version = "0.4.0"
+version = "0.5.0"
 description = "A pure Python GraphDB for attributed graphs."
 authors = [
     { name = "Mylonas Charilaos", email = "mylonas.charilaos@gmail.com" },
@@ -26,13 +26,13 @@ protobuf = ["protobuf"]
 bloom = ["pybloom-live"]
 coverage = ["coverage", "pytest"]
 docs = ["furo", "myst-parser", "sphinx"]
-rocksdb = ["pyrex-rocksdb>=0.3.0a0"]
+rocksdb = ["pyrex-rocksdb>=0.4.1"]
 arrow = ["pyarrow"]
 polars = ["polars", "pyarrow"]
-fast-ingest = ["pyarrow", "polars", "pyrex-rocksdb>=0.3.0a0"]
+fast-ingest = ["pyarrow", "polars", "pyrex-rocksdb>=0.4.1"]
 external-bench = ["arcadedb-embedded; python_version >= '3.10'", "gqlalchemy", "neo4j"]
-all = ["lmdb", "msgpack", "plyvel", "protobuf", "pybloom-live", "pyrex-rocksdb>=0.3.0a0", "pyarrow", "polars", "arcadedb-embedded; python_version >= '3.10'", "gqlalchemy", "neo4j"]
-dev = ["coverage", "furo", "lmdb", "msgpack", "myst-parser", "plyvel", "protobuf", "pybloom-live", "pyrex-rocksdb>=0.3.0a0", "pyarrow", "polars", "pytest", "sphinx", "arcadedb-embedded; python_version >= '3.10'", "gqlalchemy", "neo4j"]
+all = ["lmdb", "msgpack", "plyvel", "protobuf", "pybloom-live", "pyrex-rocksdb>=0.4.1", "pyarrow", "polars", "arcadedb-embedded; python_version >= '3.10'", "gqlalchemy", "neo4j"]
+dev = ["coverage", "furo", "lmdb", "msgpack", "myst-parser", "plyvel", "protobuf", "pybloom-live", "pyrex-rocksdb>=0.4.1", "pyarrow", "polars", "pytest", "sphinx", "arcadedb-embedded; python_version >= '3.10'", "gqlalchemy", "neo4j"]
 
 [tool.setuptools.packages.find]
 where = ["src"]

--- a/scripts/benchmark_arcadedb_vs_gestaltdb.py
+++ b/scripts/benchmark_arcadedb_vs_gestaltdb.py
@@ -145,7 +145,7 @@ def pyarrow_array(values):
     return pa.array(values)
 
 
-def open_gestaltdb(path: Path, args: argparse.Namespace) -> GraphDB:
+def open_gestaltdb(path: Path, args: argparse.Namespace, *, transactional: bool = False) -> GraphDB:
     return GraphDB(
         PyRexStore(
             path=str(path),
@@ -154,6 +154,7 @@ def open_gestaltdb(path: Path, args: argparse.Namespace) -> GraphDB:
             write_buffer_size=args.rocksdb_write_buffer_size,
             bloom_bits_per_key=args.rocksdb_bloom_bits,
             disable_wal=args.rocksdb_disable_wal,
+            transactional=transactional,
         ),
         MessagePackSerializer(),
     )
@@ -375,8 +376,9 @@ def add_rates(row: dict[str, object]) -> None:
         row["queries_per_second"] = row["iterations"] / query_seconds
 
 
-def run_gestaltdb(workload: str, args: argparse.Namespace) -> dict[str, object]:
-    row = base_row("gestaltdb-rocksdb", workload, args)
+def run_gestaltdb(workload: str, args: argparse.Namespace, *, transactional: bool = False) -> dict[str, object]:
+    engine_name = "gestaltdb-rocksdb-transactional" if transactional else "gestaltdb-rocksdb"
+    row = base_row(engine_name, workload, args)
     if importlib.util.find_spec("pyrex") is None:
         row.update({"status": "skipped", "skip_reason": "missing pyrex-rocksdb"})
         return row
@@ -387,7 +389,7 @@ def run_gestaltdb(workload: str, args: argparse.Namespace) -> dict[str, object]:
     path = Path(tempfile.mkdtemp(prefix=f"gestaltdb_arcade_compare_{workload}_", dir=args.tmp_dir))
     graph = None
     try:
-        graph = open_gestaltdb(path, args)
+        graph = open_gestaltdb(path, args, transactional=transactional)
         row["native_columnar"] = bool(getattr(graph.store, "has_native_columnar_ingestion", lambda: False)())
         shape = workload_shape(workload)
         if workload == "rocksdb_compaction":
@@ -559,7 +561,12 @@ def write_summary(output_dir: Path, rows: list[dict[str, object]]) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Benchmark gestaltdb/RocksDB against ArcadeDB graph workloads")
-    parser.add_argument("--engines", nargs="+", choices=["gestaltdb", "arcadedb"], default=["gestaltdb", "arcadedb"])
+    parser.add_argument(
+        "--engines",
+        nargs="+",
+        choices=["gestaltdb", "gestaltdb-tx", "arcadedb"],
+        default=["gestaltdb", "gestaltdb-tx", "arcadedb"],
+    )
     parser.add_argument(
         "--workloads",
         nargs="+",
@@ -592,7 +599,11 @@ def parse_args() -> argparse.Namespace:
 
 def main() -> None:
     args = parse_args()
-    runners = {"gestaltdb": run_gestaltdb, "arcadedb": run_arcadedb}
+    runners = {
+        "gestaltdb": run_gestaltdb,
+        "gestaltdb-tx": lambda workload, args: run_gestaltdb(workload, args, transactional=True),
+        "arcadedb": run_arcadedb,
+    }
     rows = []
     for repetition in range(1, args.repetitions + 1):
         for workload in args.workloads:

--- a/scripts/benchmark_external_graphdbs.py
+++ b/scripts/benchmark_external_graphdbs.py
@@ -281,7 +281,7 @@ def add_rates(row: dict[str, object]) -> None:
     row["total_seconds"] = float(row.get("ingest_seconds") or 0.0) + float(row.get("query_seconds") or 0.0)
 
 
-def open_gestaltdb(path: Path, args: argparse.Namespace) -> GraphDB:
+def open_gestaltdb(path: Path, args: argparse.Namespace, *, transactional: bool = False) -> GraphDB:
     return GraphDB(
         PyRexStore(
             path=str(path),
@@ -290,13 +290,15 @@ def open_gestaltdb(path: Path, args: argparse.Namespace) -> GraphDB:
             write_buffer_size=args.rocksdb_write_buffer_size,
             bloom_bits_per_key=args.rocksdb_bloom_bits,
             disable_wal=args.rocksdb_disable_wal,
+            transactional=transactional,
         ),
         JSONSerializer(),
     )
 
 
-def run_gestaltdb(workload: str, args: argparse.Namespace) -> dict[str, object]:
-    row = base_row("gestaltdb-rocksdb", workload, args)
+def run_gestaltdb(workload: str, args: argparse.Namespace, *, transactional: bool = False) -> dict[str, object]:
+    engine_name = "gestaltdb-rocksdb-transactional" if transactional else "gestaltdb-rocksdb"
+    row = base_row(engine_name, workload, args)
     if importlib.util.find_spec("pyrex") is None:
         row.update({"status": "skipped", "skip_reason": "missing pyrex-rocksdb"})
         return row
@@ -312,7 +314,7 @@ def run_gestaltdb(workload: str, args: argparse.Namespace) -> dict[str, object]:
     path = Path(tempfile.mkdtemp(prefix="gestaltdb_external_bench_", dir=args.tmp_dir))
     graph = None
     try:
-        graph = open_gestaltdb(path, args)
+        graph = open_gestaltdb(path, args, transactional=transactional)
 
         def ingest() -> None:
             for start, end in chunks(args.nodes, args.batch_size):
@@ -341,7 +343,7 @@ def run_gestaltdb(workload: str, args: argparse.Namespace) -> dict[str, object]:
         _, row["ingest_seconds"] = seconds(ingest)
         graph.close()
         graph = None
-        graph, row["reopen_seconds"] = seconds(lambda: open_gestaltdb(path, args))
+        graph, row["reopen_seconds"] = seconds(lambda: open_gestaltdb(path, args, transactional=transactional))
         (row["actual_nodes"], row["actual_edges"]), row["count_seconds"] = seconds(lambda: count_gestaltdb(graph))
         row["count_status"] = count_status(row, args)
         result_count, row["query_seconds"] = seconds(lambda: run_gestaltdb_workload(graph, workload, args))
@@ -748,7 +750,12 @@ def run_with_container(engine: str, workload: str, args: argparse.Namespace, run
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Benchmark GestaltDB against Neo4j, Memgraph, and ArcadeDB")
-    parser.add_argument("--engines", nargs="+", choices=["gestaltdb", "neo4j", "memgraph", "arcadedb"], default=["gestaltdb", "neo4j", "memgraph", "arcadedb"])
+    parser.add_argument(
+        "--engines",
+        nargs="+",
+        choices=["gestaltdb", "gestaltdb-tx", "neo4j", "memgraph", "arcadedb"],
+        default=["gestaltdb", "gestaltdb-tx", "neo4j", "memgraph", "arcadedb"],
+    )
     parser.add_argument("--workloads", nargs="+", choices=["ingest", "neighbors", "sample_neighbors", "bfs_depth", "typed_path"], default=["ingest", "neighbors", "sample_neighbors", "bfs_depth", "typed_path"])
     parser.add_argument("--nodes", type=int, default=10_000)
     parser.add_argument("--edges", type=int, default=50_000)
@@ -789,6 +796,7 @@ def main() -> None:
     rows = []
     runners = {
         "gestaltdb": lambda workload, args: run_gestaltdb(workload, args),
+        "gestaltdb-tx": lambda workload, args: run_gestaltdb(workload, args, transactional=True),
         "neo4j": lambda workload, args: run_with_container("neo4j", workload, args, run_bolt_engine),
         "memgraph": lambda workload, args: run_with_container("memgraph", workload, args, run_bolt_engine),
         "arcadedb": lambda workload, args: run_arcadedb(workload, args),

--- a/scripts/benchmark_matrix.py
+++ b/scripts/benchmark_matrix.py
@@ -311,12 +311,21 @@ def set_thread_env(cores: int) -> None:
 def rocksdb_configs(selected: list[str], cores: int) -> list[tuple[str, dict[str, object]]]:
     configs = {
         "default": {},
+        "transactional": {"transactional": True},
         "parallel": {"parallelism": cores, "max_background_jobs": cores},
+        "parallel-transactional": {"parallelism": cores, "max_background_jobs": cores, "transactional": True},
         "parallel-buffer64mb-bloom10": {
             "parallelism": cores,
             "max_background_jobs": cores,
             "write_buffer_size": 64 * 1024 * 1024,
             "bloom_bits_per_key": 10,
+        },
+        "parallel-buffer64mb-bloom10-transactional": {
+            "parallelism": cores,
+            "max_background_jobs": cores,
+            "write_buffer_size": 64 * 1024 * 1024,
+            "bloom_bits_per_key": 10,
+            "transactional": True,
         },
         "parallel-buffer64mb-bloom10-nowal": {
             "parallelism": cores,
@@ -347,7 +356,7 @@ def validate_dependencies(backend: str, ingestion_mode: str, serializer: str) ->
     return None
 
 
-def base_result(args, backend: str, config_name: str, cores: int, nodes: int, ingestion_mode: str) -> dict[str, object]:
+def base_result(args, backend: str, config_name: str, cores: int, nodes: int, edges: int, ingestion_mode: str) -> dict[str, object]:
     semantics = "full_object_indexes_legacy_adjacency" if ingestion_mode == "object" else "append_only_typed_adjacency_only"
     return {
         "status": "ok",
@@ -356,7 +365,7 @@ def base_result(args, backend: str, config_name: str, cores: int, nodes: int, in
         "backend_config": config_name,
         "cores": cores,
         "nodes": nodes,
-        "edges": nodes,
+        "edges": edges,
         "ingestion_mode": ingestion_mode,
         "ingestion_semantics": semantics,
         "serializer": args.serializer,
@@ -370,7 +379,8 @@ def base_result(args, backend: str, config_name: str, cores: int, nodes: int, in
 
 
 def run_one(args, backend: str, config_name: str, rocksdb_options: dict[str, object], cores: int, nodes: int, ingestion_mode: str):
-    result = base_result(args, backend, config_name, cores, nodes, ingestion_mode)
+    edges = nodes * args.edge_multiplier
+    result = base_result(args, backend, config_name, cores, nodes, edges, ingestion_mode)
     skip_reason = validate_dependencies(backend, ingestion_mode, args.serializer)
     if skip_reason:
         result.update({"status": "skipped", "skip_reason": skip_reason})
@@ -384,9 +394,9 @@ def run_one(args, backend: str, config_name: str, rocksdb_options: dict[str, obj
             graph = open_graph(db_path, backend, args.serializer, rocksdb_options)
             result["native_columnar"] = bool(getattr(graph.store, "has_native_columnar_ingestion", lambda: False)())
             if ingestion_mode == "object":
-                result.update(ingest_object(graph, nodes, nodes, args.chunk_size))
+                result.update(ingest_object(graph, nodes, edges, args.chunk_size))
             else:
-                result.update(ingest_columnar(graph, nodes, nodes, args.chunk_size, ingestion_mode))
+                result.update(ingest_columnar(graph, nodes, edges, args.chunk_size, ingestion_mode))
             graph.close()
             graph = None
 
@@ -405,11 +415,11 @@ def run_one(args, backend: str, config_name: str, rocksdb_options: dict[str, obj
         if not args.keep_dbs:
             shutil.rmtree(db_path, ignore_errors=True)
 
-    add_rates(result, nodes)
+    add_rates(result, nodes, edges)
     return result
 
 
-def add_rates(result: dict[str, object], nodes: int) -> None:
+def add_rates(result: dict[str, object], nodes: int, edges: int) -> None:
     for key, numerator_key, rate_key in (
         ("node_ingest_seconds", None, "node_ingest_rate"),
         ("edge_ingest_seconds", None, "edge_ingest_rate"),
@@ -421,7 +431,7 @@ def add_rates(result: dict[str, object], nodes: int) -> None:
         if not isinstance(elapsed, (int, float)) or elapsed <= 0:
             result[rate_key] = ""
             continue
-        numerator = result.get(numerator_key) if numerator_key else nodes
+        numerator = result.get(numerator_key) if numerator_key else (edges if key == "edge_ingest_seconds" else nodes)
         result[rate_key] = float(numerator) / elapsed if isinstance(numerator, (int, float)) else ""
 
 
@@ -443,6 +453,7 @@ def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run GestaltDB benchmark matrix")
     parser.add_argument("--backends", nargs="+", choices=["leveldb", "rocksdb"], default=["leveldb", "rocksdb"])
     parser.add_argument("--sizes", nargs="+", type=int, default=[10_000, 100_000, 1_000_000])
+    parser.add_argument("--edge-multiplier", type=int, default=1)
     parser.add_argument("--cores", nargs="+", type=int, default=[1, 2, 4])
     parser.add_argument("--ingestion-modes", nargs="+", choices=["object", "arrow", "polars"], default=["object", "arrow", "polars"])
     parser.add_argument("--serializer", choices=["pickle", "msgpack", "json", "protobuf"], default="msgpack")
@@ -457,7 +468,15 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--rocksdb-configs",
         nargs="+",
-        choices=["default", "parallel", "parallel-buffer64mb-bloom10", "parallel-buffer64mb-bloom10-nowal"],
+        choices=[
+            "default",
+            "transactional",
+            "parallel",
+            "parallel-transactional",
+            "parallel-buffer64mb-bloom10",
+            "parallel-buffer64mb-bloom10-transactional",
+            "parallel-buffer64mb-bloom10-nowal",
+        ],
         default=["default", "parallel", "parallel-buffer64mb-bloom10"],
     )
     return parser.parse_args()

--- a/src/gestaltdb/graphdb.py
+++ b/src/gestaltdb/graphdb.py
@@ -7,6 +7,7 @@ import os
 import random
 import uuid
 import base64
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, List, Optional, Union
 
 if TYPE_CHECKING:
@@ -2684,6 +2685,25 @@ class GraphDB:
         from .cypher import execute
 
         return execute(self, cypher, parameters=parameters)
+
+    @contextmanager
+    def transaction(self, **options):
+        """Run graph operations in a backend transaction when supported.
+
+        The transaction commits on clean context exit and rolls back if an
+        exception leaves the context.
+        """
+        tx_store = self.store.transaction(**options)
+        try:
+            tx_graph = GraphDB(tx_store, self.serializer)
+            tx_graph.indexed_node_properties = set(self.indexed_node_properties)
+            tx_graph.indexed_edge_properties = set(self.indexed_edge_properties)
+            yield tx_graph
+        except Exception:
+            tx_store.rollback()
+            raise
+        else:
+            tx_store.commit()
 
     def close(self):
         """Close the underlying key-value store.

--- a/src/gestaltdb/kvstores.py
+++ b/src/gestaltdb/kvstores.py
@@ -155,6 +155,8 @@ def _typed_adjacency_prefix(direction: str, node_id: bytes, edge_type: str) -> b
 class KVStore:
     """Abstract interface for a simple key-value store."""
 
+    supports_transactions = False
+
     # The basic K/V methods:
     def put(self, key: bytes, value: bytes):
         """Store a raw key/value pair."""
@@ -175,6 +177,10 @@ class KVStore:
     def close(self):
         """Close any resources owned by the store."""
         raise NotImplementedError
+
+    def transaction(self, **options):
+        """Return a transaction-bound store when supported."""
+        raise NotImplementedError("transactions are not supported by this KVStore")
 
     def put_metadata(self, key: bytes, value: bytes):
         """Store a metadata key/value pair."""
@@ -402,6 +408,8 @@ class LMDBStore(KVStore):
         >>> store = LMDBStore(path="/tmp/example_graph_lmdb")  # doctest: +SKIP
     """
 
+    supports_transactions = True
+
     def __init__(self, path='graph_lmdb', map_size=10_485_760, map_id = True, map_keys = False):
         """
         Creates/opens an LMDB environment with three named sub-databases:
@@ -462,6 +470,10 @@ class LMDBStore(KVStore):
     def close(self):
         """Close the LMDB environment."""
         self.env.close()
+
+    def transaction(self, write: bool = True, **options):
+        """Open a transaction spanning all LMDB named databases."""
+        return LMDBTransactionStore(self, write=write, **options)
 
     def put_metadata(self, key: bytes, value: bytes):
         """Store a metadata key/value pair."""
@@ -711,6 +723,251 @@ class LMDBStore(KVStore):
                 if end_value is not None and (range_value > end_value or (range_value == end_value and not include_end)):
                     break
                 yield value
+
+
+class LMDBTransactionStore(KVStore):
+    """Transaction-bound LMDB store using one environment transaction."""
+
+    supports_transactions = True
+
+    def __init__(self, parent: LMDBStore, write: bool = True, **options):
+        self.parent = parent
+        self.write = write
+        self.txn = parent.env.begin(write=write, **options)
+        self._active = True
+
+    def _check_active(self):
+        if not self._active:
+            raise RuntimeError("transaction is no longer active")
+
+    def commit(self):
+        self._check_active()
+        self.txn.commit()
+        self._active = False
+
+    def rollback(self):
+        if self._active:
+            self.txn.abort()
+            self._active = False
+
+    def close(self):
+        self.rollback()
+
+    def transaction(self, **options):
+        raise NotImplementedError("nested transactions are not supported")
+
+    def put(self, key: bytes, value: bytes):
+        self._check_active()
+
+    def get(self, key: bytes) -> bytes:
+        self._check_active()
+        return None
+
+    def delete(self, key: bytes):
+        self._check_active()
+
+    def range_iter(self, start_key: bytes, end_key: bytes):
+        self._check_active()
+        cursor = self.txn.cursor(db=self.parent.nodes_db)
+        if not cursor.set_range(start_key):
+            return
+        for key, value in cursor:
+            if key > end_key:
+                break
+            yield key, value
+
+    def put_metadata(self, key: bytes, value: bytes):
+        self._check_active()
+        self.txn.put(key, value, db=self.parent.metadata_db)
+
+    def get_metadata(self, key: bytes) -> bytes:
+        self._check_active()
+        return self.txn.get(key, db=self.parent.metadata_db)
+
+    def delete_metadata(self, key: bytes):
+        self._check_active()
+        self.txn.delete(key, db=self.parent.metadata_db)
+
+    def put_node(self, node_id: bytes, value: bytes):
+        self._check_active()
+        self.txn.put(node_id, value, db=self.parent.nodes_db)
+
+    def get_node(self, node_id: bytes) -> bytes:
+        self._check_active()
+        return self.txn.get(node_id, db=self.parent.nodes_db)
+
+    def delete_node(self, node_id: bytes):
+        self._check_active()
+        self.txn.delete(node_id, db=self.parent.nodes_db)
+
+    def put_edge(self, edge_id: bytes, value: bytes):
+        self._check_active()
+        self.txn.put(edge_id, value, db=self.parent.edges_db)
+
+    def get_edge(self, edge_id: bytes) -> bytes:
+        self._check_active()
+        return self.txn.get(edge_id, db=self.parent.edges_db)
+
+    def delete_edge(self, edge_id: bytes):
+        self._check_active()
+        self.txn.delete(edge_id, db=self.parent.edges_db)
+
+    def put_nodes_bulk(self, keys_and_values: dict[bytes, bytes]):
+        self._check_active()
+        for node_id, value in keys_and_values.items():
+            self.txn.put(node_id, value, db=self.parent.nodes_db)
+
+    def get_nodes_bulk(self, node_ids: list[bytes]) -> dict[bytes, bytes]:
+        self._check_active()
+        results = {}
+        for node_id in node_ids:
+            value = self.txn.get(node_id, db=self.parent.nodes_db)
+            if value is not None:
+                results[node_id] = value
+        return results
+
+    def put_edges_bulk(self, keys_and_values: dict[bytes, bytes]):
+        self._check_active()
+        for edge_id, value in keys_and_values.items():
+            self.txn.put(edge_id, value, db=self.parent.edges_db)
+
+    def get_edges_bulk(self, edge_ids: list[bytes]) -> dict[bytes, bytes]:
+        self._check_active()
+        results = {}
+        for edge_id in edge_ids:
+            value = self.txn.get(edge_id, db=self.parent.edges_db)
+            if value is not None:
+                results[edge_id] = value
+        return results
+
+    def get_edge_keys_generator(self, num_edges=None, key_offset=None):
+        yield from self._key_generator(self.parent.edges_db, num_edges, key_offset)
+
+    def get_node_keys_generator(self, num_nodes=None, key_offset=None):
+        yield from self._key_generator(self.parent.nodes_db, num_nodes, key_offset)
+
+    def _key_generator(self, db, limit=None, key_offset=None):
+        self._check_active()
+        yielded = 0
+        cursor = self.txn.cursor(db=db)
+        if key_offset is not None:
+            if not cursor.set_range(key_offset):
+                return
+        else:
+            if not cursor.first():
+                return
+        for key, _ in cursor:
+            yield key
+            yielded += 1
+            if limit is not None and yielded == limit:
+                break
+
+    def put_adjacency(self, node_id: bytes, value: bytes) -> None:
+        self._check_active()
+        self.txn.put(node_id, value, db=self.parent.adj_db)
+
+    def get_adjacency(self, node_id: bytes) -> Optional[bytes]:
+        self._check_active()
+        if not isinstance(node_id, bytes):
+            raise Exception('Get adjacency requires the bytes! (serialized data)')
+        return self.txn.get(node_id, db=self.parent.adj_db)
+
+    def put_adjacency_bulk(self, adj_dict: Dict[bytes, bytes]) -> None:
+        self._check_active()
+        for node_id, value in adj_dict.items():
+            self.txn.put(node_id, value, db=self.parent.adj_db)
+
+    def get_adjacency_bulk(self, node_ids: List[bytes]) -> Dict[bytes, bytes]:
+        self._check_active()
+        results = {}
+        for node_id in node_ids:
+            value = self.txn.get(node_id, db=self.parent.adj_db)
+            if value is not None:
+                results[node_id] = value
+        return results
+
+    def delete_adjacency(self, node_id: bytes):
+        self._check_active()
+        self.txn.delete(node_id, db=self.parent.adj_db)
+
+    def put_typed_adjacency(self, source_id: bytes, target_id: bytes, edge_type: str, edge_id: bytes):
+        self.put_typed_adjacency_bulk([(source_id, target_id, edge_type, edge_id)])
+
+    def put_typed_adjacency_bulk(self, records: list[tuple[bytes, bytes, str, bytes]]):
+        self._check_active()
+        for source_id, target_id, edge_type, edge_id in records:
+            self.txn.put(_typed_adjacency_key("out", source_id, edge_type, edge_id), target_id, db=self.parent.typed_adj_db)
+            self.txn.put(_typed_adjacency_key("in", target_id, edge_type, edge_id), source_id, db=self.parent.typed_adj_db)
+
+    def delete_typed_adjacency(self, source_id: bytes, target_id: bytes, edge_type: str, edge_id: bytes):
+        self._check_active()
+        self.txn.delete(_typed_adjacency_key("out", source_id, edge_type, edge_id), db=self.parent.typed_adj_db)
+        self.txn.delete(_typed_adjacency_key("in", target_id, edge_type, edge_id), db=self.parent.typed_adj_db)
+
+    def iter_typed_adjacency(self, node_id: bytes, edge_type: str, direction: str = "out"):
+        self._check_active()
+        prefix = _typed_adjacency_prefix(direction, node_id, edge_type)
+        cursor = self.txn.cursor(db=self.parent.typed_adj_db)
+        if not cursor.set_range(prefix):
+            return
+        for key, neighbor_id in cursor:
+            if not key.startswith(prefix):
+                break
+            yield key[len(prefix):], neighbor_id
+
+    def put_index_entry(self, index_name: str, key_parts: list[bytes], value: bytes):
+        self._check_active()
+        self.txn.put(_index_key(index_name, key_parts, value), value, db=self.parent.index_db)
+
+    def put_index_entries_bulk(self, entries: list[tuple[str, list[bytes], bytes]]):
+        self._check_active()
+        for index_name, key_parts, value in entries:
+            self.txn.put(_index_key(index_name, key_parts, value), value, db=self.parent.index_db)
+
+    def delete_index_entry(self, index_name: str, key_parts: list[bytes], value: bytes):
+        self._check_active()
+        self.txn.delete(_index_key(index_name, key_parts, value), db=self.parent.index_db)
+
+    def iter_index_prefix(self, index_name: str, key_parts: list[bytes]):
+        self._check_active()
+        prefix = _index_prefix(index_name, key_parts)
+        cursor = self.txn.cursor(db=self.parent.index_db)
+        if not cursor.set_range(prefix):
+            return
+        for key, value in cursor:
+            if not key.startswith(prefix):
+                break
+            yield value
+
+    def put_range_index_entry(self, index_name: str, key_parts: list[bytes], range_value: bytes, value: bytes):
+        self._check_active()
+        self.txn.put(_range_index_key(index_name, key_parts, range_value, value), value, db=self.parent.index_db)
+
+    def put_range_index_entries_bulk(self, entries: list[tuple[str, list[bytes], bytes, bytes]]):
+        self._check_active()
+        for index_name, key_parts, range_value, value in entries:
+            self.txn.put(_range_index_key(index_name, key_parts, range_value, value), value, db=self.parent.index_db)
+
+    def delete_range_index_entry(self, index_name: str, key_parts: list[bytes], range_value: bytes, value: bytes):
+        self._check_active()
+        self.txn.delete(_range_index_key(index_name, key_parts, range_value, value), db=self.parent.index_db)
+
+    def iter_range_index(self, index_name: str, key_parts: list[bytes], start_value: bytes | None = None, end_value: bytes | None = None, include_start: bool = True, include_end: bool = True):
+        self._check_active()
+        prefix = _range_index_prefix(index_name, key_parts)
+        start_key = prefix if start_value is None else prefix + start_value
+        cursor = self.txn.cursor(db=self.parent.index_db)
+        if not cursor.set_range(start_key):
+            return
+        for key, value in cursor:
+            if not key.startswith(prefix):
+                break
+            range_value = key[len(prefix):].split(_TYPED_ADJ_SEP, 1)[0]
+            if start_value is not None and (range_value < start_value or (range_value == start_value and not include_start)):
+                continue
+            if end_value is not None and (range_value > end_value or (range_value == end_value and not include_end)):
+                break
+            yield value
 
 
 # =========================================
@@ -1040,6 +1297,8 @@ class PyRexStore(KVStore):
         write_buffer_size=None,
         bloom_bits_per_key=None,
         disable_wal=False,
+        transactional=False,
+        transaction_db_options=None,
     ):
         """Open a PyRex/RocksDB store with optional tuning settings."""
         try:
@@ -1060,9 +1319,26 @@ class PyRexStore(KVStore):
             options.use_block_based_bloom_filter(bloom_bits_per_key)
 
         self._pyrex = pyrex
-        self.db = pyrex.PyRocksDB(path, options)
+        self.transactional = transactional
+        if transactional:
+            if not getattr(pyrex, "has_transactions", False):
+                raise ImportError("PyRexStore transactional mode requires pyrex-rocksdb>=0.4.1")
+            transaction_db_options = transaction_db_options or pyrex.TransactionDBOptions()
+            self.db = pyrex.TransactionDB(path, options, transaction_db_options)
+            self.supports_transactions = True
+        else:
+            self.db = pyrex.PyRocksDB(path, options)
+            self.supports_transactions = False
         self.write_options = pyrex.WriteOptions()
         self.write_options.disable_wal = disable_wal
+
+    def transaction(self, transaction_options=None, **options):
+        """Open a RocksDB transaction-bound store."""
+        if not self.transactional:
+            raise NotImplementedError("PyRexStore transactions require PyRexStore(transactional=True)")
+        transaction_options = transaction_options or self._pyrex.TransactionOptions()
+        txn = self.db.begin_transaction(self.write_options, transaction_options)
+        return PyRexTransactionStore(self, txn)
 
     def _key(self, prefix: bytes, key: bytes) -> bytes:
         """Build a prefixed RocksDB key."""
@@ -1076,6 +1352,35 @@ class PyRexStore(KVStore):
         """Return whether this PyRex runtime exposes native columnar writes."""
         return hasattr(self.db, "write_columnar_batch")
 
+    def _put_raw(self, key: bytes, value: bytes):
+        self.db.put(key, value, self.write_options)
+
+    def _get_raw(self, key: bytes) -> bytes:
+        return self.db.get(key)
+
+    def _delete_raw(self, key: bytes):
+        self.db.delete(key, self.write_options)
+
+    def _write_batch(self, batch):
+        self.db.write(batch, self.write_options)
+
+    def _iter_key_values_from(self, start_key: bytes):
+        temp_txn = None
+        if hasattr(self.db, "new_iterator"):
+            iterator = self.db.new_iterator()
+        else:
+            temp_txn = self.db.begin_transaction(self.write_options)
+            iterator = temp_txn.new_iterator()
+        try:
+            iterator.seek(start_key)
+            while iterator.valid():
+                yield iterator.key(), iterator.value()
+                iterator.next()
+            iterator.check_status()
+        finally:
+            if temp_txn is not None and temp_txn.is_active:
+                temp_txn.rollback()
+
     def _write_columnar_batch(self, keys: list[bytes], values: list[bytes]) -> None:
         """Write key/value lists through PyRex's native columnar API."""
         self.db.write_columnar_batch(keys, values, write_options=self.write_options)
@@ -1084,42 +1389,32 @@ class PyRexStore(KVStore):
         """Yield unprefixed keys for a prefixed key range."""
         yielded = 0
         start_key = prefix if key_offset is None else prefix + key_offset
-        iterator = self.db.new_iterator()
-        iterator.seek(start_key)
-        while iterator.valid():
-            key = iterator.key()
+        for key, _ in self._iter_key_values_from(start_key):
             if not key.startswith(prefix):
                 break
             yield key[len(prefix):]
             yielded += 1
             if limit is not None and yielded == limit:
                 break
-            iterator.next()
-        iterator.check_status()
 
     def put(self, key: bytes, value: bytes):
         """Store a raw key/value pair in the shared RocksDB keyspace."""
-        self.db.put(key, value, self.write_options)
+        self._put_raw(key, value)
 
     def get(self, key: bytes) -> bytes:
         """Return a raw value by key."""
-        return self.db.get(key)
+        return self._get_raw(key)
 
     def delete(self, key: bytes):
         """Delete a raw key/value pair."""
-        self.db.delete(key, self.write_options)
+        self._delete_raw(key)
 
     def range_iter(self, start_key: bytes, end_key: bytes):
         """Yield raw records whose keys fall within an inclusive range."""
-        iterator = self.db.new_iterator()
-        iterator.seek(start_key)
-        while iterator.valid():
-            key = iterator.key()
+        for key, value in self._iter_key_values_from(start_key):
             if key > end_key:
                 break
-            yield key, iterator.value()
-            iterator.next()
-        iterator.check_status()
+            yield key, value
 
     def close(self):
         """Close the RocksDB database."""
@@ -1127,34 +1422,34 @@ class PyRexStore(KVStore):
 
     def put_metadata(self, key: bytes, value: bytes):
         """Store a metadata key/value pair."""
-        self.db.put(self._key(b"M", key), value, self.write_options)
+        self._put_raw(self._key(b"M", key), value)
 
     def get_metadata(self, key: bytes) -> bytes:
         """Return a metadata value by key, or ``None``."""
-        return self.db.get(self._key(b"M", key))
+        return self._get_raw(self._key(b"M", key))
 
     def delete_metadata(self, key: bytes):
         """Delete a metadata key/value pair."""
-        self.db.delete(self._key(b"M", key), self.write_options)
+        self._delete_raw(self._key(b"M", key))
 
     def put_node(self, node_id: bytes, value: bytes):
         """Store a serialized node by byte key."""
-        self.db.put(self._key(b"N", node_id), value, self.write_options)
+        self._put_raw(self._key(b"N", node_id), value)
 
     def get_node(self, node_id: bytes) -> bytes:
         """Return serialized node bytes by key, or ``None``."""
-        return self.db.get(self._key(b"N", node_id))
+        return self._get_raw(self._key(b"N", node_id))
 
     def delete_node(self, node_id: bytes):
         """Delete a node by byte key."""
-        self.db.delete(self._key(b"N", node_id), self.write_options)
+        self._delete_raw(self._key(b"N", node_id))
 
     def put_nodes_bulk(self, keys_and_values: dict[bytes, bytes]):
         """Store many serialized nodes in one RocksDB write batch."""
         batch = self._pyrex.PyWriteBatch()
         for node_id, value in keys_and_values.items():
             batch.put(self._key(b"N", node_id), value)
-        self.db.write(batch, self.write_options)
+        self._write_batch(batch)
 
     def ingest_nodes_columnar(self, node_list, *, native: bool = True):
         """Store columnar nodes, using native PyRex ingestion when available."""
@@ -1176,22 +1471,22 @@ class PyRexStore(KVStore):
 
     def put_edge(self, edge_id: bytes, value: bytes):
         """Store a serialized edge by byte key."""
-        self.db.put(self._key(b"E", edge_id), value, self.write_options)
+        self._put_raw(self._key(b"E", edge_id), value)
 
     def get_edge(self, edge_id: bytes) -> bytes:
         """Return serialized edge bytes by key, or ``None``."""
-        return self.db.get(self._key(b"E", edge_id))
+        return self._get_raw(self._key(b"E", edge_id))
 
     def delete_edge(self, edge_id: bytes):
         """Delete an edge by byte key."""
-        self.db.delete(self._key(b"E", edge_id), self.write_options)
+        self._delete_raw(self._key(b"E", edge_id))
 
     def put_edges_bulk(self, keys_and_values: dict[bytes, bytes]):
         """Store many serialized edges in one RocksDB write batch."""
         batch = self._pyrex.PyWriteBatch()
         for edge_id, value in keys_and_values.items():
             batch.put(self._key(b"E", edge_id), value)
-        self.db.write(batch, self.write_options)
+        self._write_batch(batch)
 
     def get_edges_bulk(self, edge_ids: list[bytes]) -> dict[bytes, bytes]:
         """Return serialized edges for the requested keys."""
@@ -1212,18 +1507,18 @@ class PyRexStore(KVStore):
 
     def put_adjacency(self, node_id: bytes, value: bytes) -> None:
         """Store a serialized adjacency list for a node."""
-        self.db.put(self._key(b"A", node_id), value, self.write_options)
+        self._put_raw(self._key(b"A", node_id), value)
 
     def get_adjacency(self, node_id: bytes) -> Optional[bytes]:
         """Return a serialized adjacency list for a node."""
-        return self.db.get(self._key(b"A", node_id))
+        return self._get_raw(self._key(b"A", node_id))
 
     def put_adjacency_bulk(self, adj_dict: Dict[bytes, bytes]) -> None:
         """Store many serialized adjacency lists in one RocksDB write batch."""
         batch = self._pyrex.PyWriteBatch()
         for node_id, value in adj_dict.items():
             batch.put(self._key(b"A", node_id), value)
-        self.db.write(batch, self.write_options)
+        self._write_batch(batch)
 
     def get_adjacency_bulk(self, node_ids: List[bytes]) -> Dict[bytes, bytes]:
         """Return serialized adjacency lists for the requested nodes."""
@@ -1236,7 +1531,7 @@ class PyRexStore(KVStore):
 
     def delete_adjacency(self, node_id: bytes):
         """Delete a serialized adjacency list for a node."""
-        self.db.delete(self._key(b"A", node_id), self.write_options)
+        self._delete_raw(self._key(b"A", node_id))
 
     def put_typed_adjacency(self, source_id: bytes, target_id: bytes, edge_type: str, edge_id: bytes):
         """Store forward and reverse typed adjacency records."""
@@ -1248,7 +1543,7 @@ class PyRexStore(KVStore):
         for source_id, target_id, edge_type, edge_id in records:
             batch.put(self._typed_key("out", source_id, edge_type, edge_id), target_id)
             batch.put(self._typed_key("in", target_id, edge_type, edge_id), source_id)
-        self.db.write(batch, self.write_options)
+        self._write_batch(batch)
 
     def ingest_edges_columnar(self, edge_list, *, append_only: bool = True, native: bool = True, maintain_indexes: bool = True):
         """Store columnar typed edges, using native PyRex ingestion when available."""
@@ -1292,81 +1587,125 @@ class PyRexStore(KVStore):
         batch = self._pyrex.PyWriteBatch()
         batch.delete(self._typed_key("out", source_id, edge_type, edge_id))
         batch.delete(self._typed_key("in", target_id, edge_type, edge_id))
-        self.db.write(batch, self.write_options)
+        self._write_batch(batch)
 
     def iter_typed_adjacency(self, node_id: bytes, edge_type: str, direction: str = "out"):
         """Yield typed adjacency ``(edge_id, neighbor_id)`` pairs."""
         prefix = self._typed_key(direction, node_id, edge_type)
-        iterator = self.db.new_iterator()
-        iterator.seek(prefix)
-        while iterator.valid():
-            key = iterator.key()
+        for key, value in self._iter_key_values_from(prefix):
             if not key.startswith(prefix):
                 break
-            yield key[len(prefix):], iterator.value()
-            iterator.next()
-        iterator.check_status()
+            yield key[len(prefix):], value
 
     def put_index_entry(self, index_name: str, key_parts: list[bytes], value: bytes):
         """Store one sorted index entry."""
-        self.db.put(_index_key(index_name, key_parts, value), value, self.write_options)
+        self._put_raw(_index_key(index_name, key_parts, value), value)
 
     def put_index_entries_bulk(self, entries: list[tuple[str, list[bytes], bytes]]):
         """Store many sorted index entries in one write batch."""
         batch = self._pyrex.PyWriteBatch()
         for index_name, key_parts, value in entries:
             batch.put(_index_key(index_name, key_parts, value), value)
-        self.db.write(batch, self.write_options)
+        self._write_batch(batch)
 
     def delete_index_entry(self, index_name: str, key_parts: list[bytes], value: bytes):
         """Delete one sorted index entry."""
-        self.db.delete(_index_key(index_name, key_parts, value), self.write_options)
+        self._delete_raw(_index_key(index_name, key_parts, value))
 
     def iter_index_prefix(self, index_name: str, key_parts: list[bytes]):
         """Yield values whose index key starts with ``key_parts``."""
         prefix = _index_prefix(index_name, key_parts)
-        iterator = self.db.new_iterator()
-        iterator.seek(prefix)
-        while iterator.valid():
-            key = iterator.key()
+        for key, value in self._iter_key_values_from(prefix):
             if not key.startswith(prefix):
                 break
-            yield iterator.value()
-            iterator.next()
-        iterator.check_status()
+            yield value
 
     def put_range_index_entry(self, index_name: str, key_parts: list[bytes], range_value: bytes, value: bytes):
         """Store one sorted range index entry."""
-        self.db.put(_range_index_key(index_name, key_parts, range_value, value), value, self.write_options)
+        self._put_raw(_range_index_key(index_name, key_parts, range_value, value), value)
 
     def put_range_index_entries_bulk(self, entries: list[tuple[str, list[bytes], bytes, bytes]]):
         """Store many sorted range index entries in one write batch."""
         batch = self._pyrex.PyWriteBatch()
         for index_name, key_parts, range_value, value in entries:
             batch.put(_range_index_key(index_name, key_parts, range_value, value), value)
-        self.db.write(batch, self.write_options)
+        self._write_batch(batch)
 
     def delete_range_index_entry(self, index_name: str, key_parts: list[bytes], range_value: bytes, value: bytes):
         """Delete one sorted range index entry."""
-        self.db.delete(_range_index_key(index_name, key_parts, range_value, value), self.write_options)
+        self._delete_raw(_range_index_key(index_name, key_parts, range_value, value))
 
     def iter_range_index(self, index_name: str, key_parts: list[bytes], start_value: bytes | None = None, end_value: bytes | None = None, include_start: bool = True, include_end: bool = True):
         """Yield values whose range index key falls between start and end values."""
         prefix = _range_index_prefix(index_name, key_parts)
         start_key = prefix if start_value is None else prefix + start_value
-        iterator = self.db.new_iterator()
-        iterator.seek(start_key)
-        while iterator.valid():
-            key = iterator.key()
+        for key, value in self._iter_key_values_from(start_key):
             if not key.startswith(prefix):
                 break
             range_value = key[len(prefix):].split(_TYPED_ADJ_SEP, 1)[0]
             if start_value is not None and (range_value < start_value or (range_value == start_value and not include_start)):
-                iterator.next()
                 continue
             if end_value is not None and (range_value > end_value or (range_value == end_value and not include_end)):
                 break
-            yield iterator.value()
+            yield value
+
+
+class PyRexTransactionStore(PyRexStore):
+    """Transaction-bound PyRex/RocksDB store."""
+
+    supports_transactions = True
+
+    def __init__(self, parent: PyRexStore, txn):
+        self.parent = parent
+        self.db = parent.db
+        self.txn = txn
+        self._pyrex = parent._pyrex
+        self.write_options = parent.write_options
+        self.transactional = True
+
+    def _check_active(self):
+        if not self.txn.is_active:
+            raise RuntimeError("transaction is no longer active")
+
+    def commit(self):
+        self._check_active()
+        self.txn.commit(self.write_options)
+
+    def rollback(self):
+        if self.txn.is_active:
+            self.txn.rollback()
+
+    def close(self):
+        self.rollback()
+
+    def transaction(self, **options):
+        raise NotImplementedError("nested transactions are not supported")
+
+    def has_native_columnar_ingestion(self) -> bool:
+        return False
+
+    def _put_raw(self, key: bytes, value: bytes):
+        self._check_active()
+        self.txn.put(key, value)
+
+    def _get_raw(self, key: bytes) -> bytes:
+        self._check_active()
+        return self.txn.get(key)
+
+    def _delete_raw(self, key: bytes):
+        self._check_active()
+        self.txn.delete(key)
+
+    def _write_batch(self, batch):
+        self._check_active()
+        self.txn.write(batch)
+
+    def _iter_key_values_from(self, start_key: bytes):
+        self._check_active()
+        iterator = self.txn.new_iterator()
+        iterator.seek(start_key)
+        while iterator.valid():
+            yield iterator.key(), iterator.value()
             iterator.next()
         iterator.check_status()
 

--- a/tests/test_transactions.py
+++ b/tests/test_transactions.py
@@ -1,0 +1,98 @@
+import importlib.util
+
+import pytest
+
+from gestaltdb.graphdb import Edge, GraphDB, Node
+from gestaltdb.kvstores import KVStore, LMDBStore, PyRexStore
+from gestaltdb.serializers import PickleSerializer
+
+
+def _transactional_backends():
+    backends = []
+    if importlib.util.find_spec("lmdb") is not None:
+        backends.append(("lmdb", lambda path: LMDBStore(path=str(path))))
+    if importlib.util.find_spec("pyrex") is not None:
+        import pyrex
+
+        if getattr(pyrex, "has_transactions", False):
+            backends.append(("pyrex", lambda path: PyRexStore(path=str(path), transactional=True)))
+    return backends
+
+
+TRANSACTIONAL_BACKENDS = _transactional_backends()
+TRANSACTIONAL_BACKEND_PARAMS = TRANSACTIONAL_BACKENDS or [
+    pytest.param(None, marks=pytest.mark.skip(reason="no transactional backend installed"))
+]
+
+
+def test_kvstore_default_transaction_is_unsupported():
+    with pytest.raises(NotImplementedError):
+        KVStore().transaction()
+
+
+@pytest.mark.parametrize("backend", TRANSACTIONAL_BACKEND_PARAMS, ids=lambda item: item[0] if item is not None else "none")
+def test_graph_transaction_commits_node_and_indexes(backend, tmp_path):
+    backend_name, store_factory = backend
+    graph = GraphDB(store_factory(tmp_path / backend_name), PickleSerializer(), indexed_node_properties=["kind"])
+    try:
+        with graph.transaction() as tx:
+            tx.put_node(Node(node_id="drug-1", labels=["Drug"], properties={"kind": "drug"}))
+
+        assert graph.get_node(b"drug-1").properties == {"kind": "drug"}
+        assert [node.get_id for node in graph.nodes_by_label("Drug")] == ["drug-1"]
+        assert [node.get_id for node in graph.nodes_by_property("kind", "drug")] == ["drug-1"]
+    finally:
+        graph.close()
+
+
+@pytest.mark.parametrize("backend", TRANSACTIONAL_BACKEND_PARAMS, ids=lambda item: item[0] if item is not None else "none")
+def test_graph_transaction_rolls_back_node_and_indexes(backend, tmp_path):
+    backend_name, store_factory = backend
+    graph = GraphDB(store_factory(tmp_path / backend_name), PickleSerializer(), indexed_node_properties=["kind"])
+    try:
+        with pytest.raises(RuntimeError):
+            with graph.transaction() as tx:
+                tx.put_node(Node(node_id="drug-1", labels=["Drug"], properties={"kind": "drug"}))
+                raise RuntimeError("abort")
+
+        assert graph.get_node(b"drug-1") is None
+        assert graph.nodes_by_label("Drug") == []
+        assert graph.nodes_by_property("kind", "drug") == []
+    finally:
+        graph.close()
+
+
+@pytest.mark.parametrize("backend", TRANSACTIONAL_BACKEND_PARAMS, ids=lambda item: item[0] if item is not None else "none")
+def test_graph_transaction_commits_edge_adjacency_and_type_index(backend, tmp_path):
+    backend_name, store_factory = backend
+    graph = GraphDB(store_factory(tmp_path / backend_name), PickleSerializer())
+    try:
+        with graph.transaction() as tx:
+            tx.put_node(Node(node_id="n1"))
+            tx.put_node(Node(node_id="n2"))
+            tx.put_edge(Edge(edge_id="e1", source="n1", target="n2", properties={"type": "rel"}))
+
+        assert graph.get_edge(b"e1") is not None
+        assert graph.neighbors_by_edge_type("n1", "rel") == [b"n2"]
+        assert [edge.get_id for edge in graph.edges_by_type("rel")] == ["e1"]
+    finally:
+        graph.close()
+
+
+@pytest.mark.parametrize("backend", TRANSACTIONAL_BACKEND_PARAMS, ids=lambda item: item[0] if item is not None else "none")
+def test_graph_transaction_rolls_back_edge_adjacency_and_type_index(backend, tmp_path):
+    backend_name, store_factory = backend
+    graph = GraphDB(store_factory(tmp_path / backend_name), PickleSerializer())
+    try:
+        graph.put_node(Node(node_id="n1"))
+        graph.put_node(Node(node_id="n2"))
+        with pytest.raises(RuntimeError):
+            with graph.transaction() as tx:
+                tx.put_edge(Edge(edge_id="e1", source="n1", target="n2", properties={"type": "rel"}))
+                raise RuntimeError("abort")
+
+        assert graph.get_edge(b"e1") is None
+        assert graph.neighbors_by_edge_type("n1", "rel") == []
+        assert graph.edges_by_type("rel") == []
+    finally:
+        graph.close()

--- a/uv.lock
+++ b/uv.lock
@@ -1292,7 +1292,7 @@ wheels = [
 
 [[package]]
 name = "gestaltdb"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "google" },


### PR DESCRIPTION
## Summary
- Add optional graph-level transactions via `GraphDB.transaction()` and `KVStore.transaction()`.
- Implement transaction-bound stores for LMDB and opt-in PyRex/RocksDB `PyRexStore(transactional=True)` using `pyrex-rocksdb>=0.4.1`.
- Keep the default PyRex/RocksDB fast path non-transactional for native columnar ingestion.
- Add transaction tests for commit/rollback and graph/index/adjacency consistency.
- Add benchmark support for transaction-capable RocksDB in quick, matrix, external graph DB, and ArcadeDB comparison runners.
- Update installation, storage backend, and performance docs with transaction guidance and benchmark results.
- Bump GestaltDB minor version to 0.5.0.

## Benchmarks
- Ran external graph DB benchmark with GestaltDB/RocksDB, GestaltDB/RocksDB transactional, Neo4j, Memgraph, and ArcadeDB on 100k nodes / 500k edges.
- Reran older ArcadeDB comparison suite with default and transaction-capable RocksDB.
- Documented results in `docs/performance.rst`.

## Verification
- `python3 -m compileall src scripts benchmarks.py tests`
- `python3 -m pytest tests/test_transactions.py tests/test_kvstores.py tests/test_graphdb_interfaces.py` -> 8 passed, 73 skipped
- Sphinx HTML docs build via temporary docs venv
